### PR TITLE
When executing 'sel clear' command through ipmitool, add a clear sel event

### DIFF
--- a/lanserv/OpenIPMI/serv.h
+++ b/lanserv/OpenIPMI/serv.h
@@ -365,6 +365,7 @@ struct sys_data_s {
     pef_data_t *cpef;
     ipmi_sol_t *sol;
     lmc_data_t *mc;
+    unsigned char clear_sel_event;
 
     void *(*alloc)(sys_data_t *sys, int size);
     void (*free)(sys_data_t *sys, void *data);

--- a/lanserv/bmc_storage.c
+++ b/lanserv/bmc_storage.c
@@ -605,6 +605,20 @@ handle_clear_sel(lmc_data_t    *mc,
     mc->sel.flags &= ~0x80;
 
     rewrite_sels(mc);
+
+    /* add clear sel event if set */
+    if (mc->sysinfo->clear_sel_event) {
+        unsigned char event[13] = {0x69, 0x4F, 0x1F, 0x57, 0x20, 0x00, 0x04, 0x10, 0xf3, 0x6f, 0x02, 0xff, 0xff};
+        unsigned int r;
+        int rv;
+        rv = ipmi_mc_add_to_sel(mc, 0x02, &event[0], &r);
+        if (rv == EAGAIN)
+            rdata[0] = IPMI_OUT_OF_SPACE_CC;
+        else if (rv)
+            rdata[0] = IPMI_UNKNOWN_ERR_CC;
+        else 
+            rdata[0] = 0;
+    }
 }
 
 static void

--- a/lanserv/config.c
+++ b/lanserv/config.c
@@ -864,6 +864,8 @@ read_config(sys_data_t *sys,
 	    err = get_sock_addr(&tokptr,
 				&sys->console_addr, &sys->console_addr_len,
 				NULL, SOCK_STREAM, &errstr);
+    } else if (strcmp(tok, "clear_sel_event") == 0) {
+	    err = get_bool(&tokptr, &sys->clear_sel_event, &errstr);
 	} else {
 	    errstr = "Invalid configuration option";
 	    err = -1;

--- a/lanserv/ipmi_sim.c
+++ b/lanserv/ipmi_sim.c
@@ -1421,6 +1421,7 @@ main(int argc, const char *argv[])
     sysinfo.cfree = ifree;
     sysinfo.lan_channel_init = lan_channel_init;
     sysinfo.ser_channel_init = ser_channel_init;
+    sysinfo.clear_sel_event = 1;
     data.sys = &sysinfo;
 
     err = pipe(sigpipeh);


### PR DESCRIPTION
the clear_sel_event flag was set to true default, if you want to disable this feature, you can add "clear_sel_event false" in vbmc.conf.

@fub2 @turtle-fly @sharkconi @PaynePei 
