### PR TITLE
Refine i2c device access with master write-read

### DIFF
--- a/lanserv/OpenIPMI/mcserv.h
+++ b/lanserv/OpenIPMI/mcserv.h
@@ -403,4 +403,13 @@ void ipmi_mc_set_aux_fw_revision(lmc_data_t *mc,
 				 unsigned char aux_fw_revision[4]);
 const char *get_lanserv_version(void);
 
+
+int ipmi_mc_add_i2c_data(lmc_data_t *mc,
+        unsigned char bridged_mc_addr,
+        unsigned char slave_address,
+        unsigned char offset,
+        unsigned int length,
+        void *data);
+
+
 #endif /* __MCSERV_H */

--- a/lanserv/bmc.h
+++ b/lanserv/bmc.h
@@ -197,6 +197,21 @@ typedef struct led_data_s
     unsigned char def_override_color;
 } led_data_t;
 
+typedef struct i2c_data_s
+{
+    unsigned char length;
+    unsigned char data[0x100];
+} i2c_data_t;
+
+typedef struct i2c_slave_s i2c_slave_t;
+struct i2c_slave_s
+{
+    sem_t sem;
+    unsigned char addr; /* command code for PMBUS PSU*/
+    i2c_data_t *data[0xff];
+    i2c_slave_t *next;
+};
+
 struct lmc_data_s
 {
     emu_data_t *emu;
@@ -332,6 +347,7 @@ struct lmc_data_s
     struct timeval watchdog_time; /* Set time */
     struct timeval watchdog_expiry; /* Timeout time */
     ipmi_timer_t *watchdog_timer;
+    i2c_slave_t *devlist;
 };
 
 typedef struct atca_site_s

--- a/lanserv/bmc_app.c
+++ b/lanserv/bmc_app.c
@@ -1314,11 +1314,13 @@ handle_master_write_read(lmc_data_t *mc,
     unsigned int read_count = 0;
     off_t offset = 0;
     i2c_slave_t *sdev = NULL;
+    int write = 0;
 
     if (check_msg_length(msg, 3, rdata, rdata_len))
         return;
     
     slave_address = msg->data[1] & (unsigned char)~0x1;
+    write = msg->data[1] & 0x1;
     read_count = msg->data[2];
     offset = msg->data[3];
 
@@ -1330,7 +1332,7 @@ handle_master_write_read(lmc_data_t *mc,
         return;
     }
 
-    if (read_count > 0) { /* it should be read command */
+    if (!write) { /* it should be read command */
         int rv;
 
         rv = i2c_slave_read(sdev, offset, read_count - 1, &rdata[2]);


### PR DESCRIPTION
```
Support command for users to add more i2c devices.

command:
mc_add_i2c_data <mc> <bridged mc> <slave> <offset> <length>
data <data1> <data2> ...

Prior to using this command, bridged MC should be added and be enabled
as the following:

mc_add <bridged MC> <..> <...>
mc_enable <bridged MC>
```

e.g.
- Add 0x68 management controller
  mc_add 0x68 1 no-device-sdrs 1 0 0 159 0 0 dynsens
  mc_enable 0x68
- Add slave device 0xb0 behind 0x68 MC, and add the data for offset 0x9e
  mc_add_i2c_data 0x20 0x68 0xb0 0x9e 0x10 data \
  'F '3 '3 '6 '7 '2 '1 '6 '0 '9 '0 '0 '0 '8 '2 '3
