### PR TITLE
Add command for get user password.

### DIFF
--- a/lanserv/OpenIPMI/mcserv.h
+++ b/lanserv/OpenIPMI/mcserv.h
@@ -411,5 +411,6 @@ int ipmi_mc_add_i2c_data(lmc_data_t *mc,
         unsigned int length,
         void *data);
 
+int get_user_password(lmc_data_t *mc, const char *username, const char *password);
 
 #endif /* __MCSERV_H */

--- a/lanserv/bmc_app.c
+++ b/lanserv/bmc_app.c
@@ -815,6 +815,27 @@ handle_set_user_password(lmc_data_t    *mc,
     *rdata_len = 1;
 }
 
+int
+get_user_password(lmc_data_t *mc, const char *username, const char *password)
+{
+    uint8_t user;
+    user_t *users;
+
+    if (strlen(username) > 16)
+        return -1;
+
+    read_persist_users(mc->sysinfo);
+    users = ipmi_mc_get_users(mc);
+    for (user = 0; user < MAX_USERS + 1; user++) {
+        if (!strncmp(username, users[user].username, strlen(username))) {
+            memcpy(password, users[user].pw, strlen(users[user].pw));
+            return 0;
+        }
+    }
+
+    return -1;
+}
+
 static void
 handle_set_channel_access(lmc_data_t    *mc,
 			  msg_t         *msg,

--- a/lanserv/emu_cmd.c
+++ b/lanserv/emu_cmd.c
@@ -1236,6 +1236,30 @@ mc_add_i2c_data(emu_out_t *out, emu_data_t *emu, lmc_data_t *mc, char **toks)
     return 0;
 }
 
+static int 
+mc_get_user_password(emu_out_t *out, emu_data_t *emu, lmc_data_t *mc, char **toks)
+{
+    const char *username; 
+    const char password[20] = {0};
+    int rv;
+
+    username = mystrtok(NULL, " \t\n", toks);
+    if (!username) {
+        out->printf(out, "**Error: can't find username.\n");
+        return EINVAL;
+    }
+
+    rv = get_user_password(mc, username, &password[0]);
+
+    if (rv) {
+        out->printf(out, "**Error: failed to get password for %s\n", username);
+        return EINVAL;
+    }
+
+    out->printf(out, "%s\n", password);
+
+}
+
 static struct emu_cmd_info cmds[] =
 {
     { "quit",		NOMC,		quit,			 &cmds[1] },
@@ -1269,6 +1293,7 @@ static struct emu_cmd_info cmds[] =
     { "debug",		NOMC,		debug_cmd,		 &cmds[29] },
     { "sel_list",	MC,		sel_list,		&cmds[30] },
     { "mc_add_i2c_data", MC, mc_add_i2c_data, &cmds[31] },
+    { "get_user_password", MC, mc_get_user_password, &cmds[32] },
     { "persist",	NOMC,		persist_cmd,		 NULL },
     { NULL }
 };


### PR DESCRIPTION
Background: if the user password was changed through ipmitool command
line by users, how to know the password?

Solution: Added command "get_user_password" to get the user password.

e.g. Get user 'admin' password, you can run the command on the ipmisim
console:

get_user_password 0x20 admin
