### PR TITLE
Fix SMS_ATN operation in VM codec for serial

### DIFF
--- a/lanserv/serial_ipmi.c
+++ b/lanserv/serial_ipmi.c
@@ -925,6 +925,8 @@ vm_set_attn(channel_t *chan, int val, int irq)
     unsigned int len = 0;
     unsigned char c[3];
 
+    if (val && si->do_attn) {
+
     if (!val)
 	vm_add_char(VM_CMD_NOATTN, c, &len);
     else if (irq)
@@ -935,6 +937,8 @@ vm_set_attn(channel_t *chan, int val, int irq)
     c[len++] = VM_CMD_CHAR;
 
     raw_send(si, c, len);
+
+    }
 }
 
 static int


### PR DESCRIPTION
For a channel using serial medium, ipmi_sim provides
`VM` codec to talk with KVM.
This codec setup will set `set_atn` handler for
this specific channel.
This leads `ipmi_emu_handle_msg` set `SMS_ATN` flags,
but nobody clears the flags later.
When `ipmi_si_drv` in ESXi is loading, it watches
SMS_ATN flags, if it is set, ipmi_si_drv keeps querying
flags and it's reason, until someone clears this flags.
In our failure case, it is an endless loop.

Signed-off-by: Conghui Chen <conghui.chen@emc.com>