### PR TITLE
Hotfix/set attn only on si

### DIFF
--- a/include/OpenIPMI/ipmi_bits.h
+++ b/include/OpenIPMI/ipmi_bits.h
@@ -464,6 +464,17 @@ const char *ipmi_get_color_string(unsigned int val);
 #define IPMI_SDR_MC_CONFIRMATION_RECORD		0x13
 #define IPMI_SDR_MC_BMC_MESSAGE_CHANNEL_RECORD	0x14
 
+
+/*
+ * Send message command bits
+ */
+#define IPMI_MSG_BRIDGE_NO_TRACK 0x0
+#define IPMI_MSG_BRIDGE_TRACK_REQUEST 0x01
+#define IPMI_MSG_BRIDGE_SEND_RAW 0x2
+#define IPMI_MSG_BRIDGE_SHIFT 6
+#define IPMI_MSG_BRIDGE_TRACK_MASK (0x3<<IPMI_MSG_BRIDGE_SHIFT)
+
+
 /*
  * Misc values
  */

--- a/lanserv/bmc.c
+++ b/lanserv/bmc.c
@@ -399,10 +399,12 @@ ipmi_emu_handle_msg(emu_data_t    *emu,
 	/* An encapsulated command, put the response into the receive q. */
 	channel_t *bchan = srcmc->channels[15];
 
+    if ((omsg->data[0] & IPMI_MSG_BRIDGE_TRACK_MASK) == (IPMI_MSG_BRIDGE_NO_TRACK << IPMI_MSG_BRIDGE_SHIFT)) {
 	if (bchan->recv_in_q) {
 	    if (bchan->recv_in_q(srcmc->channels[15], rmsg))
 		return;
 	}
+    }
 
 	ordata[0] = 0;
 	*ordata_len = 1;
@@ -425,8 +427,10 @@ ipmi_emu_handle_msg(emu_data_t    *emu,
 	    srcmc->recv_q_tail = rmsg;
 	}
 	srcmc->msg_flags |= IPMI_MC_MSG_FLAG_RCV_MSG_QUEUE;
+    if ((omsg->data[0] & IPMI_MSG_BRIDGE_TRACK_MASK) == (IPMI_MSG_BRIDGE_NO_TRACK << IPMI_MSG_BRIDGE_SHIFT)) {
 	if (bchan->set_atn)
 		bchan->set_atn(bchan, 1, IPMI_MC_MSG_INTS_ON(mc));
+    }
     } else if (emu->sysinfo->debug & DEBUG_MSG)
 	debug_log_raw_msg(emu->sysinfo, ordata, *ordata_len,
 			  "Response message:");

--- a/lanserv/serial_ipmi.c
+++ b/lanserv/serial_ipmi.c
@@ -925,8 +925,6 @@ vm_set_attn(channel_t *chan, int val, int irq)
     unsigned int len = 0;
     unsigned char c[3];
 
-    if (val && si->do_attn) {
-
     if (!val)
 	vm_add_char(VM_CMD_NOATTN, c, &len);
     else if (irq)
@@ -937,8 +935,6 @@ vm_set_attn(channel_t *chan, int val, int irq)
     c[len++] = VM_CMD_CHAR;
 
     raw_send(si, c, len);
-
-    }
 }
 
 static int


### PR DESCRIPTION
According to IPMI spec 22.7, set ATTN flag when message is sent
on System Interface, and the command is `No Tracking`, which means
bit[6:7] of request data [1] is 00b.

If send message command is sent by IOL, the command bridge mode
will be `Track Request`, which won't call attention from System
Interface.

Signed-off-by: Conghui Chen <conghui.chen@emc.com>